### PR TITLE
switch to asm-based-transformer to test with it and sync up with ToolUtils.transformJarFile(File inJarFile, File outputFolder)

### DIFF
--- a/galleon-plugins/pom.xml
+++ b/galleon-plugins/pom.xml
@@ -45,7 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly-extras</groupId>
+<!--
       <artifactId>no-dependencies-transformer</artifactId>
+-->
+      <artifactId>asm-based-transformer</artifactId>
+
       <version>1.0.0.Alpha1-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
@@ -786,7 +786,7 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
 
     private Path transform(MavenArtifact artifact, Path targetDir) throws IOException {
         System.out.println("Transforming+" + artifact);
-        JakartaTransformer.transformJarFile(artifact.getPath().toFile(), targetDir.resolve(artifact.getPath().getFileName()).toFile());
+        JakartaTransformer.transformJarFile(artifact.getPath().toFile(), targetDir.toFile());
         return targetDir.resolve(artifact.getPath().getFileName());
     }
 

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/transformer/JakartaTransformer.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/transformer/JakartaTransformer.java
@@ -24,7 +24,7 @@ public class JakartaTransformer {
         ToolUtils.transformModules(modules, targetModules, null, false, null);
     }
 
-    public static void transformJarFile(final File inJarFile, final File outJarFile) throws IOException {
-        ToolUtils.transformJarFile(inJarFile, outJarFile, null);
+    public static void transformJarFile(final File inJarFile, final File outputFolder) throws IOException {
+        ToolUtils.transformJarFile(inJarFile, outputFolder, null);
     }
 }


### PR DESCRIPTION
We made an API change yesterday that the second parameter to transformJarFile should represent the output folder.  

I'm also trying a change on https://github.com/scottmarlow/batavia/tree/classforname2 to try transformation of className parameter passed to Class.forName(), which doesn't seem to work yet.  I'll let you know when that does work.  

By not working, it appears that the infinispan-commons-9.4.18.Final.jar didn't get modified as it should of (it was transformed from javax => jakarta but the calls to Class.forName() were not updated).

cc @ropalka 
